### PR TITLE
gtable: fix for bug introduced in e40149679abf25191f43511f05ddbc8c2dc…

### DIFF
--- a/src/lib/gtable/gtable.c
+++ b/src/lib/gtable/gtable.c
@@ -146,7 +146,12 @@ static int gtable_field_access(
 		return -ERANGE;
 	}
 
-	if ((write == 1) && (*value >= (1ull << value_width))) {
+	/* Check if "value" fits in "value_width" bits.
+	 * If value_width is 64, the check will fail, but any
+	 * 64-bit value will surely fit. */
+	if ((write == 1) &&
+	    (value_width < 64) &&
+	    (*value >= (1ull << value_width))) {
 		loge("gtable_access: Warning, cannot store %" PRIX64
 		     " inside %" PRIu64 " bits!", *value, value_width);
 		*value &= (1ull << value_width) - 1;


### PR DESCRIPTION
…c9bbc

* ptp registers need a full 64-bit access via gtable_pack and gtable_unpack
* the gtable functions were not ready to handle this corner-case and reported
  "Warning, cannot store 1 inside 64 bits!" errors.

Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>