### PR TITLE
Sja1105et pqrs compliance bugfix

### DIFF
--- a/src/lib/clock/rgmii.c
+++ b/src/lib/clock/rgmii.c
@@ -50,7 +50,7 @@ int sja1105_cgu_rgmii_tx_clk_config(
 	const int txc_offsets_et[] = {0x16, 0x1D, 0x24, 0x2B, 0x32};
 	/* UM11040.pdf, Table 81, CGU Register overview */
 	const int txc_offsets_pqrs[] = {0x16, 0x1C, 0x22, 0x28, 0x2E};
-   const int *txc_offsets;
+	const int *txc_offsets;
 	uint8_t packed_buf[BUF_LEN];
 	struct  sja1105_cgu_mii_control txc;
 

--- a/src/lib/clock/rgmii.c
+++ b/src/lib/clock/rgmii.c
@@ -47,9 +47,17 @@ int sja1105_cgu_rgmii_tx_clk_config(
 	int clksrc;
 	const int BUF_LEN = 4;
 	/* UM10944.pdf, Table 78, CGU Register overview */
-	const int txc_offsets[] = {0x16, 0x1D, 0x24, 0x2B, 0x32};
+	const int txc_offsets_et[] = {0x16, 0x1D, 0x24, 0x2B, 0x32};
+	/* UM11040.pdf, Table 81, CGU Register overview */
+	const int txc_offsets_pqrs[] = {0x16, 0x1C, 0x22, 0x28, 0x2E};
+   const int *txc_offsets;
 	uint8_t packed_buf[BUF_LEN];
 	struct  sja1105_cgu_mii_control txc;
+
+	/* E/T and P/Q/R/S compatibility */
+	txc_offsets = IS_ET(spi_setup->device_id) ?
+	                     txc_offsets_et :
+	                     txc_offsets_pqrs;
 
 	if (speed_mbps == 1000) {
 		clksrc = CLKSRC_PLL0;
@@ -78,7 +86,7 @@ int sja1105_rgmii_cfg_pad_tx_config(struct sja1105_spi_setup *spi_setup, int por
 {
 	const int BUF_LEN = 4;
 	uint8_t packed_buf[BUF_LEN];
-	/* UM10944.pdf, Table 86, AGU Register overview */
+	/* UM10944.pdf, Table 86, ACU Register overview */
 	int     pad_mii_tx_offsets[] = {0x00, 0x02, 0x04, 0x06, 0x08};
 	struct  sja1105_cfg_pad_mii_tx pad_mii_tx;
 

--- a/src/lib/clock/rmii.c
+++ b/src/lib/clock/rmii.c
@@ -46,7 +46,10 @@ int sja1105_cgu_rmii_ref_clk_config(struct sja1105_spi_setup *spi_setup,
 	struct  sja1105_cgu_mii_control ref_clk;
 	uint8_t packed_buf[BUF_LEN];
 	/* UM10944.pdf, Table 78, CGU Register overview */
-	const int ref_clk_offsets[] = {0x15, 0x1C, 0x23, 0x2A, 0x31};
+	const int ref_clk_offsets_et[] = {0x15, 0x1C, 0x23, 0x2A, 0x31};
+	/* UM11040.pdf, Table 81, CGU Register overview */
+	const int ref_clk_offsets_pqrs[] = {0x15, 0x1B, 0x21, 0x27, 0x2D};
+	const int *ref_clk_offsets;
 	const int clk_sources[] = {
 		CLKSRC_MII0_TX_CLK,
 		CLKSRC_MII1_TX_CLK,
@@ -54,6 +57,11 @@ int sja1105_cgu_rmii_ref_clk_config(struct sja1105_spi_setup *spi_setup,
 		CLKSRC_MII3_TX_CLK,
 		CLKSRC_MII4_TX_CLK,
 	};
+
+	/* E/T and P/Q/R/S compatibility */
+	ref_clk_offsets = IS_ET(spi_setup->device_id) ?
+	                     ref_clk_offsets_et :
+	                     ref_clk_offsets_pqrs;
 
 	/* Payload for packed_buf */
 	ref_clk.clksrc    = clk_sources[port];
@@ -75,7 +83,15 @@ int sja1105_cgu_rmii_ext_tx_clk_config(struct sja1105_spi_setup *spi_setup,
 	struct  sja1105_cgu_mii_control ext_tx_clk;
 	uint8_t packed_buf[BUF_LEN];
 	/* UM10944.pdf, Table 78, CGU Register overview */
-	const int ext_tx_clk_offsets[] = {0x18, 0x1F, 0x26, 0x2D, 0x34};
+	const int ext_tx_clk_offsets_et[] = {0x18, 0x1F, 0x26, 0x2D, 0x34};
+	/* UM11040.pdf, Table 81, CGU Register overview */
+	const int ext_tx_clk_offsets_pqrs[] = {0x17, 0x1D, 0x23, 0x29, 0x2F};
+	const int *ext_tx_clk_offsets;
+
+	/* E/T and P/Q/R/S compatibility */
+	ext_tx_clk_offsets = IS_ET(spi_setup->device_id) ?
+	                     ext_tx_clk_offsets_et :
+	                     ext_tx_clk_offsets_pqrs;
 
 	/* Payload for packed_buf */
 	ext_tx_clk.clksrc    = CLKSRC_PLL1;


### PR DESCRIPTION
The CGU register map has changed from E/T to P/Q/R/S decives. This patch takes account of this.