### PR TITLE
lib: tool: initial support for SGMII table in static config

### DIFF
--- a/src/lib/include/static-config.h
+++ b/src/lib/include/static-config.h
@@ -61,6 +61,7 @@
 #define SIZE_GENERAL_PARAMS_ENTRY_PQRS          44
 #define SIZE_RETAGGING_ENTRY                    8
 #define SIZE_XMII_MODE_PARAMS_ENTRY             4
+#define SIZE_SGMII_ENTRY                        144
 
 /* UM10944.pdf Page 11, Table 2. Configuration Blocks */
 #define BLKID_SCHEDULE_TABLE                     0x00
@@ -83,6 +84,7 @@
 #define BLKID_GENERAL_PARAMS_TABLE               0x11
 #define BLKID_RETAGGING_TABLE                    0x12
 #define BLKID_XMII_MODE_PARAMS_TABLE             0x4E
+#define BLKID_SGMII_TABLE                        0xC8
 
 #define MAX_SCHEDULE_COUNT                       1024
 #define MAX_SCHEDULE_ENTRY_POINTS_COUNT          2048
@@ -102,6 +104,7 @@
 #define MAX_GENERAL_PARAMS_COUNT                 1
 #define MAX_RETAGGING_COUNT                      32
 #define MAX_XMII_PARAMS_COUNT                    1
+#define MAX_SGMII_COUNT                          1
 #define MAX_AVB_PARAMS_COUNT                     1
 #define MAX_CLK_SYNC_COUNT                       1
 
@@ -314,6 +317,17 @@ struct sja1105_avb_params_entry {
 	uint64_t srcmeta;
 };
 
+struct sja1105_sgmii_entry {
+	uint64_t digital_error_cnt;
+	uint64_t digital_control_2;
+	uint64_t debug_control;
+	uint64_t test_control;
+	uint64_t autoneg_control;
+	uint64_t digital_control_1;
+	uint64_t autoneg_adv;
+	uint64_t basic_control;
+};
+
 struct sja1105_vl_lookup_entry {
 	uint64_t format;
 	uint64_t port;
@@ -434,6 +448,7 @@ struct sja1105_static_config {
 	STATIC_CONFIG_MEMBER(vl_policing, MAX_VL_POLICING_COUNT);
 	STATIC_CONFIG_MEMBER(vl_lookup, MAX_VL_LOOKUP_COUNT);
 	STATIC_CONFIG_MEMBER(retagging, MAX_RETAGGING_COUNT);
+	STATIC_CONFIG_MEMBER(sgmii, MAX_SGMII_COUNT);
 };
 
 #include "clock.h"
@@ -463,6 +478,7 @@ DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(schedule_params);
 DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(schedule);
 DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(vlan_lookup);
 DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(xmii_params);
+DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(sgmii);
 DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(vl_forwarding_params);
 DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(vl_forwarding);
 DEFINE_COMMON_HEADERS_FOR_CONFIG_TABLE(vl_policing);

--- a/src/lib/static-config/static-config.c
+++ b/src/lib/static-config/static-config.c
@@ -215,6 +215,11 @@ int sja1105_static_config_add_entry(struct sja1105_table_header *hdr, void *buf,
 		POPULATE_CONFIG_TABLE(, xmii_params, buf, MAX_XMII_PARAMS_COUNT, "xMII Parameters");
 		return SIZE_XMII_MODE_PARAMS_ENTRY;
 	}
+	case BLKID_SGMII_TABLE:
+	{
+		POPULATE_CONFIG_TABLE(, sgmii, buf, MAX_SGMII_COUNT, "SGMII Table");
+		return SIZE_SGMII_ENTRY;
+	}
 	default:
 		printf("Unknown Table %" PRIX64 "\n", hdr->block_id);
 		return -1;
@@ -624,6 +629,11 @@ sja1105_static_config_pack(void *buf, struct sja1105_static_config *config)
 	                     BLKID_XMII_MODE_PARAMS_TABLE,
 	                     sja1105_xmii_params_entry_pack,
 	                     config->xmii_params);
+	PACK_TABLE_IN_BUF_FN(config->sgmii_count,
+	                     SIZE_SGMII_ENTRY,
+	                     BLKID_SGMII_TABLE,
+	                     sja1105_sgmii_entry_pack,
+	                     config->sgmii);
 	/* Final header */
 	header.block_id = 0;      /* Does not matter */
 	header.len = 0;           /* Marks that header is final */
@@ -657,6 +667,7 @@ sja1105_static_config_get_length(struct sja1105_static_config *config)
 	header_count += (config->avb_params_count != 0);
 	header_count += (config->general_params_count != 0);
 	header_count += (config->xmii_params_count != 0);
+	header_count += (config->sgmii_count != 0);
 	header_count += 1; /* Ending header */
 	sum += SIZE_SJA1105_DEVICE_ID;
 	sum += header_count * (SIZE_TABLE_HEADER + 4); /* plus CRC at the end */
@@ -678,6 +689,7 @@ sja1105_static_config_get_length(struct sja1105_static_config *config)
 	sum += config->avb_params_count * (IS_PQRS(config->device_id) ? SIZE_AVB_PARAMS_ENTRY_PQRS : SIZE_AVB_PARAMS_ENTRY_ET);
 	sum += config->general_params_count * (IS_PQRS(config->device_id) ? SIZE_GENERAL_PARAMS_ENTRY_PQRS : SIZE_GENERAL_PARAMS_ENTRY_ET);
 	sum += config->xmii_params_count * SIZE_XMII_MODE_PARAMS_ENTRY;
+	sum += config->sgmii_count * SIZE_SGMII_ENTRY;
 	sum -= 4; /* Last header does not have an extra CRC because there is no data */
 	logv("total: %d bytes", sum);
 	return sum;

--- a/src/lib/static-config/tables/sgmii.c
+++ b/src/lib/static-config/tables/sgmii.c
@@ -1,0 +1,127 @@
+/******************************************************************************
+ * Copyright (c) 2018, NXP Semiconductors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+/* These are our own include files */
+#include <lib/include/static-config.h>
+#include <lib/include/gtable.h>
+#include <common.h>
+
+static void
+sja1105_sgmii_entry_access(void *buf,
+                           struct sja1105_sgmii_entry *entry,
+                           int write)
+{
+	int  (*pack_or_unpack)(void*, uint64_t*, int, int, int);
+	int    size = SIZE_SGMII_ENTRY;
+	uint64_t tmp;
+
+	if (write == 0) {
+		pack_or_unpack = gtable_unpack;
+		memset(entry, 0, sizeof(*entry));
+	} else {
+		pack_or_unpack = gtable_pack;
+		memset(buf, 0, size);
+	}
+	pack_or_unpack(buf, &entry->digital_error_cnt, 1151, 1120, size);
+	pack_or_unpack(buf, &entry->digital_control_2, 1119, 1088, size);
+	pack_or_unpack(buf, &entry->debug_control,      383,  352, size);
+	pack_or_unpack(buf, &entry->test_control,       351,  320, size);
+	pack_or_unpack(buf, &entry->autoneg_control,    287,  256, size);
+	pack_or_unpack(buf, &entry->digital_control_1,  255,  224, size);
+	pack_or_unpack(buf, &entry->autoneg_adv,        223,  192, size);
+	pack_or_unpack(buf, &entry->basic_control,      191,  160, size);
+	/* Reserved areas */
+	if (write == 1) {
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp, 1087, 1056, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp, 1055, 1024, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp, 1023,  992, size);
+		tmp = 0x00000100ull; gtable_pack(buf, &tmp,  991,  960, size);
+		tmp = 0x0000023Full; gtable_pack(buf, &tmp,  959,  928, size);
+		tmp = 0x0000000Aull; gtable_pack(buf, &tmp,  927,  896, size);
+		tmp = 0x00001C22ull; gtable_pack(buf, &tmp,  895,  864, size);
+		tmp = 0x00000001ull; gtable_pack(buf, &tmp,  863,  832, size);
+		tmp = 0x00000003ull; gtable_pack(buf, &tmp,  831,  800, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  799,  768, size);
+		tmp = 0x00000001ull; gtable_pack(buf, &tmp,  767,  736, size);
+		tmp = 0x00000005ull; gtable_pack(buf, &tmp,  735,  704, size);
+		tmp = 0x00000101ull; gtable_pack(buf, &tmp,  703,  672, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  671,  640, size);
+		tmp = 0x00000001ull; gtable_pack(buf, &tmp,  639,  608, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  607,  576, size);
+		tmp = 0x0000000Aull; gtable_pack(buf, &tmp,  575,  544, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  543,  512, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  511,  480, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  479,  448, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  447,  416, size);
+		tmp = 0x0000899Cull; gtable_pack(buf, &tmp,  415,  384, size);
+		tmp = 0x0000000Aull; gtable_pack(buf, &tmp,  319,  288, size);
+		tmp = 0x00000004ull; gtable_pack(buf, &tmp,  159,  128, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,  127,   96, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,   95,   64, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,   63,   32, size);
+		tmp = 0x00000000ull; gtable_pack(buf, &tmp,   31,    0, size);
+	}
+}
+/*
+ * sja1105_sgmii_entry_pack
+ * sja1105_sgmii_entry_unpack
+ */
+DEFINE_COMMON_PACK_UNPACK_ACCESSORS(sgmii);
+
+void
+sja1105_sgmii_entry_fmt_show(char *print_buf,
+                             char *fmt,
+                             struct sja1105_sgmii_entry *entry)
+{
+	formatted_append(print_buf, fmt, "DIGITAL_ERROR_CNT 0x%" PRIX64, entry->digital_error_cnt);
+	formatted_append(print_buf, fmt, "DIGITAL_CONTROL_2 0x%" PRIX64, entry->digital_control_2);
+	formatted_append(print_buf, fmt, "DEBUG_CONTROL     0x%" PRIX64, entry->debug_control);
+	formatted_append(print_buf, fmt, "TEST_CONTROL      0x%" PRIX64, entry->test_control);
+	formatted_append(print_buf, fmt, "AUTONEG_CONTROL   0x%" PRIX64, entry->autoneg_control);
+	formatted_append(print_buf, fmt, "DIGITAL_CONTROL_1 0x%" PRIX64, entry->digital_control_1);
+	formatted_append(print_buf, fmt, "AUTONEG_ADV       0x%" PRIX64, entry->autoneg_adv);
+	formatted_append(print_buf, fmt, "BASIC_CONTROL     0x%" PRIX64, entry->basic_control);
+}
+
+void sja1105_sgmii_entry_show(struct sja1105_sgmii_entry *entry)
+{
+	char print_buf[MAX_LINE_SIZE];
+	char *fmt = "%s\n";
+
+	memset(print_buf, 0, MAX_LINE_SIZE);
+	sja1105_sgmii_entry_fmt_show(print_buf, fmt, entry);
+	puts(print_buf);
+}
+

--- a/src/lib/static-config/tables/table-header.c
+++ b/src/lib/static-config/tables/table-header.c
@@ -147,6 +147,9 @@ void sja1105_table_header_show(struct sja1105_table_header *hdr)
 		case BLKID_XMII_MODE_PARAMS_TABLE:
 			printf("xMII Mode Parameters Table");
 			break;
+		case BLKID_SGMII_TABLE:
+			printf("SGMII Table");
+			break;
 		default:
 			printf("Unknown Table %" PRIX64 " ", hdr->block_id);
 	}

--- a/src/tool/config-modify.c
+++ b/src/tool/config-modify.c
@@ -732,6 +732,55 @@ out:
 	return rc;
 }
 
+static int sgmii_table_entry_modify(
+		struct sja1105_static_config *config,
+		int    entry_index,
+		char  *field_name,
+		char  *field_val)
+{
+	const char *options[] = {
+		"digital_error_cnt",
+		"digital_control_2",
+		"debug_control",
+		"test_control",
+		"autoneg_control",
+		"digital_control_1",
+		"autoneg_adv",
+		"basic_control",
+	};
+	uint64_t *fields[] = {
+		&config->sgmii[entry_index].digital_error_cnt,
+		&config->sgmii[entry_index].digital_control_2,
+		&config->sgmii[entry_index].debug_control,
+		&config->sgmii[entry_index].test_control,
+		&config->sgmii[entry_index].autoneg_control,
+		&config->sgmii[entry_index].digital_control_1,
+		&config->sgmii[entry_index].autoneg_adv,
+		&config->sgmii[entry_index].basic_control,
+	};
+	int entry_field_counts[] = {1, 1, 1, 1, 1, 1, 1, 1,};
+	uint64_t tmp;
+	int rc;
+
+	if (matches(field_name, "entry-count") == 0) {
+		rc = reliable_uint64_from_string(&tmp, field_val, NULL);
+		config->sgmii_count = tmp;
+		goto out;
+	}
+	rc = get_match(field_name, options, ARRAY_SIZE(options));
+	if (rc < 0) {
+		goto out;
+	}
+	rc = generic_table_entry_modify(
+			fields[rc],
+			entry_index,
+			config->sgmii_count,
+			entry_field_counts[rc],
+			field_val);
+out:
+	return rc;
+}
+
 static int vl_lookup_table_entry_modify(
 		struct sja1105_static_config *config,
 		int    entry_index,
@@ -992,6 +1041,7 @@ staging_area_modify(struct sja1105_staging_area *staging_area,
 		"general-parameters-table",
 		"retagging-table",
 		"xmii-mode-parameters-table",
+		"sgmii-table",
 	};
 	int (*next_static_table_modify[])(struct sja1105_static_config*, \
 	                                  int, char*, char*) = {
@@ -1015,6 +1065,7 @@ staging_area_modify(struct sja1105_staging_area *staging_area,
 		general_params_table_entry_modify,
 		retagging_table_entry_modify,
 		xmii_table_entry_modify,
+		sgmii_table_entry_modify,
 	};
 	struct   sja1105_static_config *static_config;
 	uint64_t entry_index;

--- a/src/tool/config-show.c
+++ b/src/tool/config-show.c
@@ -101,6 +101,7 @@ DECLARE_TABLE_SHOW_FN(l2_lookup_params, MAX_L2_LOOKUP_PARAMS_COUNT, "L2 Address 
 DECLARE_TABLE_SHOW_FN(l2_forwarding_params, MAX_L2_FORWARDING_PARAMS_COUNT, "L2 Forwarding Parameters Table", "%-50s\n")
 DECLARE_TABLE_SHOW_FN(general_params, MAX_GENERAL_PARAMS_COUNT, "General Parameters Table", "%-30s\n")
 DECLARE_TABLE_SHOW_FN(xmii_params, MAX_XMII_PARAMS_COUNT, "xMII Mode Parameters Table", "%-35s\n")
+DECLARE_TABLE_SHOW_FN(sgmii, MAX_SGMII_COUNT, "SGMII Table", "%-35s\n")
 DECLARE_TABLE_SHOW_FN(vl_lookup, MAX_VL_LOOKUP_COUNT, "Virtual Link Address Lookup Table:", "%-35s\n")
 DECLARE_TABLE_SHOW_FN(vl_policing, MAX_VL_POLICING_COUNT, "Virtual Link Policing Table:", "%-35s\n")
 DECLARE_TABLE_SHOW_FN(vl_forwarding, MAX_VL_FORWARDING_COUNT, "Virtual Link Forwarding Table", "%-35s\n")
@@ -148,6 +149,7 @@ sja1105_staging_area_show(struct sja1105_staging_area *staging_area,
 		"general-parameters-table",
 		"retagging-table",
 		"xmii-mode-parameters-table",
+		"sgmii-table",
 	};
 	int (*next_config_table_show[])(struct sja1105_static_config *, int) = {
 		schedule_table_show,
@@ -170,6 +172,7 @@ sja1105_staging_area_show(struct sja1105_staging_area *staging_area,
 		general_params_table_show,
 		retagging_table_show,
 		xmii_params_table_show,
+		sgmii_table_show,
 	};
 	struct sja1105_static_config *static_config;
 	char *index_ptr;

--- a/src/tool/config-xml-read.c
+++ b/src/tool/config-xml-read.c
@@ -139,6 +139,7 @@ parse_config_table(xmlNode *node, struct sja1105_static_config *config)
 		"general-parameters-table",
 		"retagging-table",
 		"xmii-mode-parameters-table",
+		"sgmii-table",
 	};
 	int (*next_parse_config_table[])(xmlNode *, struct
 	                                 sja1105_static_config *) = {
@@ -162,6 +163,7 @@ parse_config_table(xmlNode *node, struct sja1105_static_config *config)
 		general_parameters_table_parse,
 		retagging_table_parse,
 		xmii_mode_parameters_table_parse,
+		sgmii_table_parse,
 	};
 	int rc;
 	table_name = (char*) node->name;

--- a/src/tool/config-xml-write.c
+++ b/src/tool/config-xml-write.c
@@ -101,6 +101,7 @@ static_config_write(xmlTextWriterPtr writer,
 		"general-parameters-table",
 		"retagging-table",
 		"xmii-mode-parameters-table",
+		"sgmii-table",
 	};
 	int (*next_write_config_table[])(xmlTextWriterPtr,
 	                                 struct sja1105_static_config *) = {
@@ -124,6 +125,7 @@ static_config_write(xmlTextWriterPtr writer,
 		general_parameters_table_write,
 		retagging_table_write,
 		xmii_mode_parameters_table_write,
+		sgmii_table_write,
 	};
 	int rc = 0;
 	unsigned int i;

--- a/src/tool/xml/read/internal.h
+++ b/src/tool/xml/read/internal.h
@@ -62,6 +62,7 @@ int clock_synchronization_parameters_table_parse(xmlNode*, struct sja1105_static
 int general_parameters_table_parse(xmlNode*, struct sja1105_static_config*);
 int retagging_table_parse(xmlNode*, struct sja1105_static_config*);
 int xmii_mode_parameters_table_parse(xmlNode*, struct sja1105_static_config*);
+int sgmii_table_parse(xmlNode*, struct sja1105_static_config*);
 int xml_read_field(void*, char*, xmlNode*);
 int xml_read_array(void*, int, char*, xmlNode*);
 

--- a/src/tool/xml/read/sgmii.c
+++ b/src/tool/xml/read/sgmii.c
@@ -1,0 +1,92 @@
+/******************************************************************************
+ * Copyright (c) 2018, NXP Semiconductors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+#include "internal.h"
+
+static int entry_get(xmlNode *node, struct sja1105_sgmii_entry *entry)
+{
+	int rc = 0;
+	rc |= xml_read_field(&entry->digital_error_cnt, "digital_error_cnt", node);
+	rc |= xml_read_field(&entry->digital_control_2, "digital_control_2", node);
+	rc |= xml_read_field(&entry->debug_control, "debug_control", node);
+	rc |= xml_read_field(&entry->test_control, "test_control", node);
+	rc |= xml_read_field(&entry->autoneg_control, "autoneg_control", node);
+	rc |= xml_read_field(&entry->digital_control_1, "digital_control_1", node);
+	rc |= xml_read_field(&entry->autoneg_adv, "autoneg_adv", node);
+	rc |= xml_read_field(&entry->basic_control, "basic_control", node);
+	if (rc < 0) {
+		loge("SGMII Table entry is incomplete!");
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static int parse_entry(xmlNode *node, struct sja1105_static_config *config)
+{
+	struct sja1105_sgmii_entry entry;
+	int rc;
+
+	if (config->sgmii_count >= MAX_SGMII_COUNT) {
+		loge("Cannot have more than %d SGMII Table entries!",
+		     MAX_SGMII_COUNT);
+		rc = -ERANGE;
+		goto out;
+	}
+	memset(&entry, 0, sizeof(entry));
+	rc = entry_get(node, &entry);
+	config->sgmii[config->sgmii_count++] = entry;
+out:
+	return rc;
+}
+
+int sgmii_table_parse(xmlNode *node, struct sja1105_static_config *config)
+{
+	xmlNode *c;
+	int rc = 0;
+
+	if (node->type != XML_ELEMENT_NODE) {
+		loge("SGMII Table node must be of element type!");
+		rc = -EINVAL;
+		goto out;
+	}
+	for (c = node->children; c != NULL; c = c->next) {
+		if (c->type != XML_ELEMENT_NODE) {
+			continue;
+		}
+		rc = parse_entry(c, config);
+		if (rc < 0) {
+			goto out;
+		}
+	}
+	logv("read %d SGMII Table entries", config->sgmii_count);
+out:
+	return rc;
+}
+

--- a/src/tool/xml/write/internal.h
+++ b/src/tool/xml/write/internal.h
@@ -64,5 +64,6 @@ int clock_synchronization_parameters_table_write(xmlTextWriterPtr, struct sja110
 int general_parameters_table_write(xmlTextWriterPtr, struct sja1105_static_config *config);
 int retagging_table_write(xmlTextWriterPtr, struct sja1105_static_config *config);
 int xmii_mode_parameters_table_write(xmlTextWriterPtr, struct sja1105_static_config *config);
+int sgmii_table_write(xmlTextWriterPtr, struct sja1105_static_config *config);
 
 #endif

--- a/src/tool/xml/write/sgmii.c
+++ b/src/tool/xml/write/sgmii.c
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright (c) 2016, NXP Semiconductors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+#include "internal.h"
+
+int
+sgmii_table_write(xmlTextWriterPtr writer,
+                  struct sja1105_static_config *config)
+{
+	int rc = 0;
+	int i;
+
+	logv("writing %d SGMII Table entries", config->sgmii_count);
+	for (i = 0; i < config->sgmii_count; i++) {
+		rc |= xmlTextWriterStartElement(writer, BAD_CAST "entry");
+		rc |= xml_write_field(writer, "index",       i);
+		rc |= xml_write_field(writer, "digital_error_cnt", config->sgmii[i].digital_error_cnt);
+		rc |= xml_write_field(writer, "digital_control_2", config->sgmii[i].digital_control_2);
+		rc |= xml_write_field(writer, "debug_control", config->sgmii[i].debug_control);
+		rc |= xml_write_field(writer, "test_control", config->sgmii[i].test_control);
+		rc |= xml_write_field(writer, "autoneg_control", config->sgmii[i].autoneg_control);
+		rc |= xml_write_field(writer, "digital_control_1", config->sgmii[i].digital_control_1);
+		rc |= xml_write_field(writer, "autoneg_adv", config->sgmii[i].autoneg_adv);
+		rc |= xml_write_field(writer, "basic_control", config->sgmii[i].basic_control);
+		rc |= xmlTextWriterEndElement(writer);
+		if (rc < 0) {
+			loge("error while writing SGMII Table element %d", i);
+			return -EINVAL;
+		}
+	}
+	return 0;
+}
+
+


### PR DESCRIPTION
* Not tested on real hardware yet
* SGMII port must be enabled by setting xMII_MODE[4] = 3
* Standard clause 22 registers for the internal SGMII PCS are
  memory-mapped starting at address 0x1F0000. The user should
  first figure out a working configuration via "sja1105-tool reg"
  and then set these statically in the staging area/xml.

Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>