### PR TITLE
Improvement/device id handling

### DIFF
--- a/src/lib/include/static-config.h
+++ b/src/lib/include/static-config.h
@@ -109,7 +109,7 @@
 #define SJA1105PR_DEVICE_ID        0xAF00030Eull
 #define SJA1105Q_DEVICE_ID         0xAE00030Eull
 #define SJA1105S_DEVICE_ID         0xAE00030Eull
-#define SJA1105_DEVICE_ID_INVALID  0xFFFFFFFFull
+#define SJA1105_NO_DEVICE_ID       0x00000000ull
 
 #define SJA1105P_PART_NR           0x9A84
 #define SJA1105Q_PART_NR           0x9A85

--- a/src/lib/include/static-config.h
+++ b/src/lib/include/static-config.h
@@ -107,8 +107,7 @@
 #define SJA1105E_DEVICE_ID         0x9C00000Cull
 #define SJA1105T_DEVICE_ID         0x9E00030Eull
 #define SJA1105PR_DEVICE_ID        0xAF00030Eull
-#define SJA1105Q_DEVICE_ID         0xAE00030Eull
-#define SJA1105S_DEVICE_ID         0xAE00030Eull
+#define SJA1105QS_DEVICE_ID        0xAE00030Eull
 #define SJA1105_NO_DEVICE_ID       0x00000000ull
 
 #define SJA1105P_PART_NR           0x9A84
@@ -119,8 +118,7 @@
 
 #define IS_PQRS(device_id) \
 	(((device_id) == SJA1105PR_DEVICE_ID) || \
-	 ((device_id) == SJA1105Q_DEVICE_ID) || \
-	 ((device_id) == SJA1105S_DEVICE_ID))
+	 ((device_id) == SJA1105QS_DEVICE_ID))
 #define IS_ET(device_id) \
 	(((device_id) == SJA1105E_DEVICE_ID) || \
 	 ((device_id) == SJA1105T_DEVICE_ID))
@@ -131,12 +129,18 @@
 #define IS_R(device_id, part_nr) \
 	(((device_id) == SJA1105PR_DEVICE_ID) && \
 	 ((part_nr) == SJA1105R_PART_NR))
+/* Same do Q and S */
+#define IS_Q(device_id, part_nr) \
+	(((device_id) == SJA1105QS_DEVICE_ID) && \
+	 ((part_nr) == SJA1105Q_PART_NR))
+#define IS_S(device_id, part_nr) \
+	(((device_id) == SJA1105QS_DEVICE_ID) && \
+	 ((part_nr) == SJA1105S_PART_NR))
 #define DEVICE_ID_VALID(device_id) \
 	(IS_ET(device_id) || IS_PQRS(device_id))
 #define SUPPORTS_TSN(device_id) \
 	(((device_id) == SJA1105T_DEVICE_ID) || \
-	 ((device_id) == SJA1105Q_DEVICE_ID) || \
-	 ((device_id) == SJA1105S_DEVICE_ID))
+	 ((device_id) == SJA1105QS_DEVICE_ID))
 
 struct sja1105_schedule_entry {
 	uint64_t winstindex;

--- a/src/lib/spi/spi-transfer.c
+++ b/src/lib/spi/spi-transfer.c
@@ -53,6 +53,7 @@ const char *SJA1105Q_DEVICE_ID_STR        = "SJA1105Q";
 const char *SJA1105R_DEVICE_ID_STR        = "SJA1105R";
 const char *SJA1105S_DEVICE_ID_STR        = "SJA1105S";
 const char *SJA1105PR_DEVICE_ID_STR       = "SJA1105P or SJA1105R";
+const char *SJA1105QS_DEVICE_ID_STR       = "SJA1105Q or SJA1105S";
 const char *SJA1105_NO_DEVICE_ID_STR      = "None";
 
 const char *sja1105_device_id_string_get(uint64_t device_id, uint64_t part_nr)
@@ -63,18 +64,19 @@ const char *sja1105_device_id_string_get(uint64_t device_id, uint64_t part_nr)
 	if (device_id == SJA1105T_DEVICE_ID) {
 		return SJA1105T_DEVICE_ID_STR;
 	}
-	/* P and R have same Device ID, and differ by Part Number */
+	/* P and R have same Device ID, and differ by Part Number.
+	 * Same do Q and S.
+	 */
 	if (IS_P(device_id, part_nr)) {
 		return SJA1105P_DEVICE_ID_STR;
 	}
-	if (device_id == SJA1105Q_DEVICE_ID) {
+	if (IS_Q(device_id, part_nr)) {
 		return SJA1105Q_DEVICE_ID_STR;
 	}
-	/* P and R have same Device ID, and differ by Part Number */
 	if (IS_R(device_id, part_nr)) {
 		return SJA1105P_DEVICE_ID_STR;
 	}
-	if (device_id == SJA1105S_DEVICE_ID) {
+	if (IS_S(device_id, part_nr)) {
 		return SJA1105S_DEVICE_ID_STR;
 	}
 	/* Fallback: if we don't know/care what the part_nr is, and we
@@ -84,6 +86,9 @@ const char *sja1105_device_id_string_get(uint64_t device_id, uint64_t part_nr)
 	 */
 	if (device_id == SJA1105PR_DEVICE_ID) {
 		return SJA1105PR_DEVICE_ID_STR;
+	}
+	if (device_id == SJA1105QS_DEVICE_ID) {
+		return SJA1105QS_DEVICE_ID_STR;
 	}
 	return SJA1105_NO_DEVICE_ID_STR;
 }
@@ -95,8 +100,7 @@ int sja1105_device_id_get(struct sja1105_spi_setup *spi_setup,
 		SJA1105E_DEVICE_ID,
 		SJA1105T_DEVICE_ID,
 		SJA1105PR_DEVICE_ID,
-		SJA1105Q_DEVICE_ID,
-		SJA1105S_DEVICE_ID,
+		SJA1105QS_DEVICE_ID,
 	};
 	uint64_t tmp_device_id;
 	uint64_t tmp_part_nr;

--- a/src/lib/spi/spi-transfer.c
+++ b/src/lib/spi/spi-transfer.c
@@ -53,7 +53,7 @@ const char *SJA1105Q_DEVICE_ID_STR        = "SJA1105Q";
 const char *SJA1105R_DEVICE_ID_STR        = "SJA1105R";
 const char *SJA1105S_DEVICE_ID_STR        = "SJA1105S";
 const char *SJA1105PR_DEVICE_ID_STR       = "SJA1105P or SJA1105R";
-const char *SJA1105_DEVICE_ID_INVALID_STR = "Invalid";
+const char *SJA1105_NO_DEVICE_ID_STR      = "None";
 
 const char *sja1105_device_id_string_get(uint64_t device_id, uint64_t part_nr)
 {
@@ -85,7 +85,7 @@ const char *sja1105_device_id_string_get(uint64_t device_id, uint64_t part_nr)
 	if (device_id == SJA1105PR_DEVICE_ID) {
 		return SJA1105PR_DEVICE_ID_STR;
 	}
-	return SJA1105_DEVICE_ID_INVALID_STR;
+	return SJA1105_NO_DEVICE_ID_STR;
 }
 
 int sja1105_device_id_get(struct sja1105_spi_setup *spi_setup,
@@ -118,14 +118,14 @@ int sja1105_device_id_get(struct sja1105_spi_setup *spi_setup,
 		loge("sja1105_spi_send_int failed");
 		goto out_error;
 	}
-	*device_id = SJA1105_DEVICE_ID_INVALID;
+	*device_id = SJA1105_NO_DEVICE_ID;
 	for (i = 0; i < ARRAY_SIZE(compatible_device_ids); i++) {
 		if (tmp_device_id == compatible_device_ids[i]) {
 			*device_id = compatible_device_ids[i];
 			break;
 		}
 	}
-	if (*device_id == SJA1105_DEVICE_ID_INVALID) {
+	if (*device_id == SJA1105_NO_DEVICE_ID) {
 		loge("Unrecognized Device ID 0x%08" PRIx64, tmp_device_id);
 		rc = -EINVAL;
 		goto out_error;
@@ -242,7 +242,7 @@ int sja1105_spi_configure(struct sja1105_spi_setup *spi_setup)
 	logv("bits per word: %d", spi_setup->bits);
 	logv("max speed: %d KHz", spi_setup->speed / 1000);
 
-	if (spi_setup->device_id == SJA1105_DEVICE_ID_INVALID) {
+	if (spi_setup->device_id == SJA1105_NO_DEVICE_ID) {
 		/* Device ID was not overridden from sja1105.conf.
 		 * Check that we are talking with a compatible
 		 * device over SPI. */

--- a/src/lib/static-config/static-config.c
+++ b/src/lib/static-config/static-config.c
@@ -550,6 +550,11 @@ sja1105_static_config_unpack(void *buf, struct sja1105_static_config *config)
 	logv("Device ID is 0x%08" PRIx64 " (%s)",
 	     config->device_id, sja1105_device_id_string_get(
 	     config->device_id, SJA1105_PART_NR_DONT_CARE));
+	if (DEVICE_ID_VALID(config->device_id) == 0) {
+		loge("Invalid device id in staging area: 0x%08" PRIx64,
+		     config->device_id);
+		goto error;
+	}
 	p += SIZE_SJA1105_DEVICE_ID;
 
 	while (1) {

--- a/src/tool/tool-config-file.c
+++ b/src/tool/tool-config-file.c
@@ -40,8 +40,8 @@
 
 const char *default_staging_area = "/etc/sja1105/.staging";
 const char *default_device = "/dev/spidev0.1";
-const uint64_t default_device_id = SJA1105_DEVICE_ID_INVALID;
-/* default_device_id of SJA1105_DEVICE_ID_INVALID signals
+const uint64_t default_device_id = SJA1105_NO_DEVICE_ID;
+/* default_device_id of SJA1105_NO_DEVICE_ID signals
  * to sja1105_spi_configure that it should attempt to read
  * the real Device ID over SPI. Its absence from sja1105.conf
  * is not an error - its presence is merely an override of the


### PR DESCRIPTION
* Remap value of SJA1105_DEVICE_ID_INVALID to 0 (to perform autodetection with no need to do anything special if you use libsja1105)
* Make proper distinction between R/S based on part_nr (they have same device id)
* Perform checks on device id present in staging area