### PR TITLE
Rework link speed fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ install: install-binaries install-configs install-manpages install-headers
 install-binaries: $(SJA1105_LIB) $(SJA1105_BIN)
 	install -m 0755 -D libsja1105.so $(DESTDIR)${libdir}/libsja1105.so
 	install -m 0755 -D sja1105-tool  $(DESTDIR)${bindir}/sja1105-tool
+	install -m 0755 -D etc/etsec_mdio $(DESTDIR)${bindir}/etsec_mdio
 
 install-configs: etc/sja1105-init etc/sja1105.conf
 	install -m 0755 -D etc/sja1105-link-speed-fixup $(DESTDIR)${sysconfdir}/init.d/S46sja1105-link-speed-fixup
@@ -151,6 +152,7 @@ uninstall:
 		rm -rf $(call get_header_destination,$(header));)
 	rm -rf $(DESTDIR)${libdir}/libsja1105.so
 	rm -rf $(DESTDIR)${bindir}/sja1105-tool
+	rm -rf $(DESTDIR)${bindir}/etsec_mdio
 	rm -rf $(DESTDIR)${sysconfdir}/init.d/S46sja1105-link-speed-fixup
 	rm -rf $(DESTDIR)${sysconfdir}/init.d/S45sja1105
 	rm -rf $(DESTDIR)${sysconfdir}/sja1105/sja1105.conf

--- a/etc/etsec_mdio
+++ b/etc/etsec_mdio
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+set -e -u -o pipefail
+
+etsec_mdio_miimadd="0x2d24528"
+etsec_mdio_miimcom="0x2d24524"
+etsec_mdio_miimcon="0x2d2452c"
+etsec_mdio_miimstat="0x2d24530"
+etsec_mdio_miimind="0x2d24534"
+
+bswap32() {
+	local value="$1"
+	printf "0x%x\n" "$((((${value} & 0xff000000) >> 24) | ((${value} & 0x00ff0000) >> 8) | ((${value} & 0x0000ff00) << 8) | ((${value} & 0x000000ff) << 24)))"
+}
+
+etsec_read32() {
+	addr="$1"
+	printf "0x%x\n" $(bswap32 $(devmem ${addr}))
+}
+
+etsec_write32() {
+	local addr="$1"
+	local value="$2"
+	devmem ${addr} 32 $(bswap32 ${value})
+}
+
+etsec_wait_until_free() {
+	while :; do
+		tmp=$(etsec_read32 ${etsec_mdio_miimind})
+		busy=$((${tmp} & 0x1))
+		notvalid=$(((${tmp} & 0x4) >> 2))
+		if [ ${notvalid} = 0 -o ${busy} = 0 ]; then
+			break
+		fi
+		sleep 1
+	done
+}
+
+etsec_mdio_read() {
+	local phy_addr="$1"
+	local reg_addr="$2"
+	etsec_write32 ${etsec_mdio_miimadd} "$((${phy_addr}<<8 | ${reg_addr}))"
+	etsec_write32 ${etsec_mdio_miimcom} "0x00000000" # read_cycle = 0
+	etsec_write32 ${etsec_mdio_miimcom} "0x00000001" # read_cycle = 1
+	etsec_wait_until_free
+	value=$(etsec_read32 ${etsec_mdio_miimstat})
+	printf "0x%x\n" ${value}
+}
+
+etsec_mdio_write() {
+	local phy_addr="$1"
+	local reg_addr="$2"
+	local value="$3"
+	etsec_write32 ${etsec_mdio_miimcom} "0x00000000" # read_cycle = 0
+	etsec_write32 ${etsec_mdio_miimadd} "$((${phy_addr}<<8 | ${reg_addr}))"
+	etsec_write32 ${etsec_mdio_miimcon} "${value}"
+}
+
+usage() {
+	echo "Usage:"
+	echo " * $0 read <phy_addr> <reg_addr>"
+	echo " * $0 write <phy_addr> <reg_addr> <reg_value>"
+	exit 1
+}
+
+[ $# -lt 1 ] && usage
+
+case "$1" in
+read)
+	shift
+	[ $# -eq 2 ] || usage
+	etsec_mdio_read $@
+	;;
+write)
+	shift
+	[ $# -eq 3 ] || usage
+	etsec_mdio_write $@
+	;;
+*)
+	usage
+	;;
+esac
+

--- a/etc/memac_mdio
+++ b/etc/memac_mdio
@@ -1,0 +1,198 @@
+#!/bin/sh
+
+set -e -u -o pipefail
+
+# Based on the Linux driver for the mEMAC MDIO controller
+# drivers/net/ethernet/freescale/xgmac_mdio.c
+
+fman_base_addr="0x1a00000"
+emi1_offset="0xfc000"
+emi2_offset="0xfd000"
+mdio_cfg_offset="0x30"
+mdio_ctl_offset="0x34"
+mdio_data_offset="0x38"
+mdio_addr_offset="0x3C" # Clause 45 only
+
+compute_reg_addresses() {
+	local mdio_bus="$1"
+	case ${mdio_bus} in
+	emi1)
+		mdio_cfg="$((${fman_base_addr} + ${emi1_offset} + ${mdio_cfg_offset}))"
+		mdio_ctl="$((${fman_base_addr} + ${emi1_offset} + ${mdio_ctl_offset}))"
+		mdio_data="$((${fman_base_addr} + ${emi1_offset} + ${mdio_data_offset}))"
+		mdio_addr="$((${fman_base_addr} + ${emi1_offset} + ${mdio_addr_offset}))"
+		;;
+	emi2)
+		mdio_cfg="$((${fman_base_addr} + ${emi2_offset} + ${mdio_cfg_offset}))"
+		mdio_ctl="$((${fman_base_addr} + ${emi2_offset} + ${mdio_ctl_offset}))"
+		mdio_data="$((${fman_base_addr} + ${emi2_offset} + ${mdio_data_offset}))"
+		mdio_addr="$((${fman_base_addr} + ${emi2_offset} + ${mdio_addr_offset}))"
+		;;
+	*)
+		usage
+		;;
+	esac
+}
+
+# Core is little endian, MDIO controller is big endian
+bswap32() {
+	local value="$1"
+	printf "0x%04x\n" "$((((${value} & 0xff000000) >> 24) | ((${value} & 0x00ff0000) >> 8) | ((${value} & 0x0000ff00) << 8) | ((${value} & 0x000000ff) << 24)))"
+}
+
+memac_read32() {
+	local addr="$1"
+	printf "0x%04x\n" $(bswap32 $(devmem ${addr}))
+}
+
+memac_write32() {
+	local addr="$1"
+	local value="$2"
+	devmem ${addr} 32 $(bswap32 ${value})
+}
+
+memac_wait_until_free() {
+	local bsy=
+	while :; do
+		bsy=$(($(memac_read32 ${mdio_cfg}) >> 31))
+		if [ ${bsy} = 0 ]; then
+			break
+		fi
+		sleep 1
+	done
+}
+
+memac_set_clause() {
+	local clause="$1"
+	# Set or unset bit 6 (ENC45 - Enable Clause 45) of MDIO_CFG
+	local tmp=$(memac_read32 ${mdio_cfg})
+	case ${clause} in
+	c22)
+		tmp=$((${tmp} & (~(1 << 6))))
+		;;
+	c45)
+		tmp=$((${tmp} | (1 << 6)))
+		;;
+	*)
+		usage
+		;;
+	esac
+	# Extend MDIO hold time (bits 2-4) to maximum possible value
+	# (7 => 57 FMan clock cycles)
+	# Also requires asserting bit EHOLD (22)
+	# Other possible MDIO_HOLD values:
+	# 0 << 2 =>  1 FMan clock cycle
+	# 1 << 2 =>  9 FMan clock cycles
+	# 2 << 2 => 17 FMan clock cycles (default reset value)
+	# 3 << 2 => 25 FMan clock cycles
+	# 4 << 2 => 33 FMan clock cycles
+	# 5 << 2 => 41 FMan clock cycles
+	# 6 << 2 => 49 FMan clock cycles
+	tmp=$((${tmp} | (7 << 2) | (1 << 22)))
+	memac_write32 ${mdio_cfg} ${tmp}
+	memac_wait_until_free
+}
+
+# LS1043DPAARM 6.5.4.3 Clause 22 Read Flow
+memac_c22_mdio_read() {
+	[ $# -eq 2 ] || usage
+	local phy_addr="$1"
+	local reg_addr="$2"
+
+	phy_addr=$((${phy_addr} & 0x1f))
+	reg_addr=$((${reg_addr} & 0x1f))
+	# Bit 15 is READ
+	memac_write32 ${mdio_ctl} "$(((1 << 15) | (${phy_addr} << 5) | ${reg_addr}))"
+	memac_wait_until_free
+	mdio_rd_er=$((($(memac_read32 ${mdio_cfg}) & 0x00000002) >> 1))
+	if [ ${mdio_rd_er} = 1 ]; then
+		echo 0xffff
+		return 1
+	fi
+	printf "0x%04x\n" $(($(memac_read32 ${mdio_data}) & 0xffff))
+}
+
+# LS1043DPAARM 6.5.4.4 Clause 22 Write Flow
+memac_c22_mdio_write() {
+	[ $# -eq 3 ] || usage
+	local phy_addr="$1"
+	local reg_addr="$2"
+	local value="$3"
+
+	phy_addr=$((${phy_addr} & 0x1f))
+	reg_addr=$((${reg_addr} & 0x1f))
+	value=$((${value} & 0xffff))
+	memac_write32 ${mdio_ctl} "$(((${phy_addr} << 5) | ${reg_addr}))"
+	memac_write32 ${mdio_data} ${value}
+	memac_wait_until_free
+}
+
+memac_c45_mdio_read() {
+	[ $# -eq 3 ] || usage
+	local port_addr="$1"
+	local dev_addr="$2"
+	local reg_addr="$3"
+
+	port_addr=$((${port_addr} & 0x1f))
+	dev_addr=$((${dev_addr} & 0x1f))
+	reg_addr=$((${reg_addr} & 0xffff))
+	memac_write32 ${mdio_addr} "${reg_addr}"
+	# Bit 15 is READ
+	memac_write32 ${mdio_ctl} "$(((1 << 15) | (${port_addr} << 5) | ${dev_addr}))"
+	memac_wait_until_free
+	mdio_rd_er=$((($(memac_read32 ${mdio_cfg}) & 0x00000002) >> 1))
+	if [ ${mdio_rd_er} = 1 ]; then
+		echo 0xffff
+		return 1
+	fi
+	printf "0x%04x\n" $(($(memac_read32 ${mdio_data}) & 0xffff))
+}
+
+memac_c45_mdio_write() {
+	[ $# -eq 4 ] || usage
+	local port_addr="$1"
+	local dev_addr="$2"
+	local reg_addr="$3"
+	local value="$4"
+
+	port_addr=$((${port_addr} & 0x1f))
+	dev_addr=$((${reg_addr} & 0x1f))
+	reg_addr=$((${reg_addr} & 0xffff))
+	value=$((${value} & 0xffff))
+	memac_write32 ${mdio_ctl} "$(((${port_addr} << 5) | ${dev_addr}))"
+	memac_write32 ${mdio_addr} "${reg_addr}"
+	memac_wait_until_free
+	memac_write32 ${mdio_data} ${value}
+	memac_wait_until_free
+}
+
+usage() {
+	echo "Usage:"
+	echo " * $0 emi1|emi2 c22 read  <phy_addr>  <reg_addr>"
+	echo " * $0 emi1|emi2 c22 write <phy_addr>  <reg_addr> <reg_value>"
+	echo " * $0 emi1|emi2 c45 read  <port_addr> <dev_addr> <reg_addr>"
+	echo " * $0 emi1|emi2 c45 write <port_addr> <dev_addr> <reg_addr> <reg_value>"
+	exit 1
+}
+
+# Need at least bus, clause and operation (read/write) to even proceed further
+[ $# -lt 3 ] && usage
+bus=$1; shift
+clause=$1; shift
+cmd=$1; shift
+
+compute_reg_addresses ${bus}
+memac_set_clause ${clause}
+
+case "${cmd}" in
+read)
+	memac_${clause}_mdio_read $@
+	;;
+write)
+	memac_${clause}_mdio_write $@
+	;;
+*)
+	usage
+	;;
+esac
+

--- a/etc/sja1105-link-speed-fixup
+++ b/etc/sja1105-link-speed-fixup
@@ -9,10 +9,6 @@ ETH3_SPEED_MBPS=1000
 ETH4_SPEED_MBPS=1000
 ETH5_SPEED_MBPS=1000
 
-# Make sure the necessary programs exists
-[ -f /usr/bin/sja1105-tool ] || exit 0
-[ -f /usr/sbin/iomem ] || exit 0
-
 mbps_to_clause_22_speed() {
 	# Clause 22, register 0 (MII Control register), Speed Selection bits
 	# are bit 13 (LSB) and bit 6 (MSB).
@@ -44,43 +40,6 @@ fixup_mac_link_speeds() {
 	sja1105-tool config upload
 }
 
-etsec_mdio_miimadd="0x2d24528"
-etsec_mdio_miimcom="0x2d24524"
-etsec_mdio_miimcon="0x2d2452c"
-
-mdio_read() {
-	phy_addr="$1"
-	reg_addr="$2"
-	iomem w32be ${etsec_mdio_miimcom} "0x00000001" >/dev/null # read_cycle = 1
-	iomem w32be ${etsec_mdio_miimadd} "$((${phy_addr}<<8 | ${reg_addr}))" >/dev/null
-	value=$(iomem r32be ${etsec_mdio_miimcon} | awk '{ print $3; }')
-	echo ${value}
-}
-
-mdio_write() {
-	phy_addr="$1"
-	reg_addr="$2"
-	value="$3"
-	iomem w32be ${etsec_mdio_miimcom} "0x00000000" >/dev/null # read_cycle = 0
-	iomem w32be ${etsec_mdio_miimadd} "$((${phy_addr}<<8 | ${reg_addr}))" >/dev/null
-	iomem w32be ${etsec_mdio_miimcon} "${value}" >/dev/null
-}
-
-do_mdio_write() {
-	phy_addr="$1"
-	reg_addr="$2"
-	value="$3"
-	while true; do
-		echo "phy ${phy_addr} register ${reg_addr}: writing $(printf 0x%x ${value})"
-		mdio_write ${phy_addr} ${reg_addr} ${value}
-		read_back_value=$(mdio_read ${phy_addr} ${reg_addr})
-		if [ $((read_back_value)) -eq $((value)) ]; then
-			break
-		fi
-		sleep 1
-	done
-}
-
 fixup_phy_link_speeds() {
 	# Clause 22, register address 0 (MII control):
 	# Bit 15: RESET
@@ -91,10 +50,10 @@ fixup_phy_link_speeds() {
 	# Bit  9: RE_AUTONEG
 	# Bit  8: DUPLEX_MODE
 	# Bit  6: SPEED_SELECT (MSB)
-	do_mdio_write 3 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH2_SPEED_MBPS})))
-	do_mdio_write 4 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH3_SPEED_MBPS})))
-	do_mdio_write 5 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH4_SPEED_MBPS})))
-	do_mdio_write 6 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH5_SPEED_MBPS})))
+	etsec_mdio write 3 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH2_SPEED_MBPS})))
+	etsec_mdio write 4 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH3_SPEED_MBPS})))
+	etsec_mdio write 5 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH4_SPEED_MBPS})))
+	etsec_mdio write 6 0 $((1<<15 | 1<<8 | $(mbps_to_clause_22_speed ${ETH5_SPEED_MBPS})))
 }
 
 info() {


### PR DESCRIPTION
 split etsec_mdio from sja1105-link-speed-fixup script

* Also make etsec_mdio use devmem (provided by busybox) in order to drop
  dependency on iomem.
* The long-term intention is to provide a proper kernel driver for PHY
  management, and move away from this script.
