### PR TITLE
helpers: drop dependency to the realpath program

### DIFF
--- a/src/helpers/setup.sh
+++ b/src/helpers/setup.sh
@@ -4,8 +4,8 @@ set -e -u -o pipefail
 
 [ -z "${TOPDIR+x}" ] && { echo "Please source envsetup before running this script."; exit 1; }
 
-SJA1105_TOPDIR=$(realpath "${TOPDIR}/../..")
-BUILD_DIR=$(realpath "${TOPDIR}/_build")
+SJA1105_TOPDIR="${TOPDIR}/../.."
+BUILD_DIR="${TOPDIR}/_build"
 if [ -d ${BUILD_DIR} ]; then
 	echo "sja1105-tool already built, exiting"
 	exit


### PR DESCRIPTION
* It's not really needed to get the job done, and on some older Ubuntu
  distribution, a different realpath program gets installed instead of
  the GNU coreutils one. This other one fails to get paths to
  directories that don't exist (such as "_build" before we're actually
  building).

Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>