### PR TITLE
lib: use %td for printf formatting of ptrdiff_t

### DIFF
--- a/src/lib/static-config/static-config.c
+++ b/src/lib/static-config/static-config.c
@@ -448,7 +448,7 @@ sja1105_static_config_unpack(void *buf, struct sja1105_static_config *config)
 		if (p != table_end) {
 			loge("WARNING: Incorrect table length for:");
 			sja1105_table_header_show(&hdr);
-			loge("Table data has %ld extra bytes compared to header!",
+			loge("Table data has %td extra bytes compared to header!",
 			     (ptrdiff_t) (table_end - p));
 			p = table_end;
 		}


### PR DESCRIPTION
* Using %ld is only valid for 64-bit, and using %d is only valid
  for 32-bit pointers.

Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>