### PR TITLE
New command to reconfigure port speed

### DIFF
--- a/src/lib/clock/cgu.c
+++ b/src/lib/clock/cgu.c
@@ -79,9 +79,9 @@ int sja1105_clocking_setup_port(struct sja1105_spi_setup *spi_setup, int port,
 	} else if (params->xmii_mode[port] == XMII_SPEED_RGMII) {
 		rgmii_clocking_setup(spi_setup, port, speed_mbps);
 	} else if (params->xmii_mode[port] == XMII_SPEED_SGMII &&
-				  IS_PQRS(spi_setup->device_id)) {
+	           IS_PQRS(spi_setup->device_id)) {
 		if ((port == 4) && (IS_R(spi_setup->device_id, spi_setup->part_nr) ||
-							  IS_S(spi_setup->device_id, spi_setup->part_nr))) {
+		                    IS_S(spi_setup->device_id, spi_setup->part_nr))) {
 			sgmii_clocking_setup(spi_setup, port, speed_mbps);
 		} else {
 			logv("Port %d is tri-stated", port);

--- a/src/lib/clock/cgu.c
+++ b/src/lib/clock/cgu.c
@@ -49,10 +49,13 @@ int sja1105_clocking_setup(struct sja1105_spi_setup *spi_setup,
 
 	for (i = 0; i < 5; i++) {
 		switch (mac_config[i].speed) {
+		case 0: speed_mbps = 1000; break;   /* speed shall be set at runtime,
+		                                       use max speed for RGMII clocking
+		                                       setup here */
 		case 1: speed_mbps = 1000; break;
 		case 2: speed_mbps = 100;  break;
 		case 3: speed_mbps = 10;   break;
-		default: loge("auto speed not yet supported"); return -1;
+		default: loge("invalid speed setting"); return -1;
 		}
 		if (params->xmii_mode[i] == XMII_SPEED_MII) {
 			mii_clocking_setup(spi_setup, i, params->phy_mac[i]);

--- a/src/lib/dynamic-config/mac-config.c
+++ b/src/lib/dynamic-config/mac-config.c
@@ -1,0 +1,175 @@
+/******************************************************************************
+ * Copyright (c) 2017, NXP Semiconductors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+/* These are our own include files */
+#include <lib/include/dynamic-config.h>
+#include <lib/include/gtable.h>
+#include <lib/include/spi.h>
+#include <lib/helpers.h>
+#include <common.h>
+
+
+
+#define SIZE_MAC_CONFIG_ENTRY_PQRS   32
+
+struct sja1105pqrs_dyn_mac_config_cmd {
+	uint64_t valid;
+	uint64_t errors;
+	uint64_t rdwrset;
+	uint64_t portidx;
+	struct sja1105_mac_config_entry entry;
+};
+
+
+
+static void
+sja1105pqrs_dyn_mac_config_cmd_pack(void *buf, struct
+                                    sja1105pqrs_dyn_mac_config_cmd *cmd)
+{
+	int  (*pack_or_unpack)(void*, uint64_t*, int, int, int);
+	uint8_t *entry_ptr = (uint8_t*) buf;
+	uint8_t *cmd_ptr   = (uint8_t*) buf + SIZE_MAC_CONFIG_ENTRY_PQRS;
+
+	pack_or_unpack = gtable_pack;
+	memset(buf, 0, SIZE_MAC_CONFIG_ENTRY_PQRS);
+
+	pack_or_unpack(cmd_ptr, &cmd->valid,     31, 31, 4);
+	pack_or_unpack(cmd_ptr, &cmd->errors,    30, 30, 4);
+	pack_or_unpack(cmd_ptr, &cmd->rdwrset,   29, 29, 4);
+	pack_or_unpack(cmd_ptr, &cmd->portidx,    2,  0, 4);
+	sja1105pqrs_mac_config_entry_pack(entry_ptr, &cmd->entry);
+}
+
+static void
+sja1105pqrs_dyn_mac_config_cmd_unpack(void *buf, struct
+                                      sja1105pqrs_dyn_mac_config_cmd *cmd)
+{
+	int  (*pack_or_unpack)(void*, uint64_t*, int, int, int);
+	uint8_t *entry_ptr = (uint8_t*) buf;
+	uint8_t *cmd_ptr   = (uint8_t*) buf + SIZE_MAC_CONFIG_ENTRY_PQRS;
+
+	pack_or_unpack = gtable_unpack;
+	memset(cmd, 0, sizeof(*cmd));
+
+	pack_or_unpack(cmd_ptr, &cmd->valid,     31, 31, 4);
+	pack_or_unpack(cmd_ptr, &cmd->errors,    30, 30, 4);
+	pack_or_unpack(cmd_ptr, &cmd->rdwrset,   29, 29, 4);
+	pack_or_unpack(cmd_ptr, &cmd->portidx,    2,  0, 4);
+	sja1105pqrs_mac_config_entry_unpack(entry_ptr, &cmd->entry);
+}
+
+static int sja1105pqrs_mac_config_commit(struct sja1105_spi_setup *spi_setup,
+                                         struct sja1105_mac_config_entry *entry,
+                                         int read_or_write,
+                                         int portidx)
+{
+	/* MAC configuration table reconfiguration register */
+	const int ENTRY_ADDR = 0x4B;
+	const int BUF_LEN = 4 + SIZE_MAC_CONFIG_ENTRY_PQRS;
+	/* SPI payload buffer */
+	uint8_t packed_buf[BUF_LEN];
+	/* Structure to hold command we are constructing */
+	struct sja1105pqrs_dyn_mac_config_cmd cmd;
+	int rc;
+
+	memset(&cmd, 0, sizeof(cmd));
+	cmd.valid     = 1;
+	cmd.rdwrset   = (read_or_write == SPI_WRITE);
+	cmd.portidx   = portidx;
+	if (read_or_write == SPI_WRITE) {
+		/* Put the argument into the SPI payload */
+		memcpy(&cmd.entry, entry, sizeof(*entry));
+	}
+
+	sja1105pqrs_dyn_mac_config_cmd_pack(packed_buf, &cmd);
+
+	/* Send SPI write operation: "read/write mac config table entry" */
+	rc = sja1105_spi_send_packed_buf(spi_setup,
+	                                 SPI_WRITE,
+	                                 ENTRY_ADDR,
+	                                 packed_buf,
+	                                 BUF_LEN);
+	if (rc < 0) {
+		loge("failed to read from spi");
+		goto out;
+	}
+
+	if (read_or_write == SPI_READ) {
+		/* If previous operation was a read, retrieve its result:
+		 * the mac config table entry requested for */
+		memset(packed_buf, 0, BUF_LEN);
+		rc = sja1105_spi_send_packed_buf(spi_setup,
+		                                 SPI_READ,
+		                                 ENTRY_ADDR,
+		                                 packed_buf,
+		                                 BUF_LEN);
+		if (rc < 0) {
+			loge("failed to read from spi");
+			goto out;
+		}
+		sja1105pqrs_dyn_mac_config_cmd_unpack(packed_buf, &cmd);
+		memcpy(entry, &cmd.entry, sizeof(*entry));
+	}
+out:
+	return rc;
+}
+
+int sja1105_mac_config_get(struct sja1105_spi_setup *spi_setup,
+                           struct sja1105_mac_config_entry *entry,
+                           int port)
+{
+	int rc;
+
+	if (IS_ET(spi_setup->device_id))
+		rc = -1;   /* TODO: Implement this for ET devices */
+	else
+		rc = sja1105pqrs_mac_config_commit(spi_setup, entry,
+		                                   SPI_READ, port);
+	return rc;
+}
+
+int sja1105_mac_config_set(struct sja1105_spi_setup *spi_setup,
+                           struct sja1105_mac_config_entry *entry,
+                           int port)
+{
+	int rc;
+
+	if (IS_ET(spi_setup->device_id))
+		rc = -1;   /* TODO: Implement this for ET devices */
+	else
+		rc = sja1105pqrs_mac_config_commit(spi_setup, entry,
+		                                   SPI_WRITE, port);
+	return rc;
+}

--- a/src/lib/include/clock.h
+++ b/src/lib/include/clock.h
@@ -149,6 +149,9 @@ void sja1105_cgu_idiv_show(struct sja1105_cgu_idiv*);
 int sja1105_cgu_idiv_config(struct sja1105_spi_setup*, int, int, int);
 int sja1105_clocking_setup(struct sja1105_spi_setup*, struct sja1105_xmii_params_entry*,
                            struct sja1105_mac_config_entry*);
+int sja1105_clocking_setup_port(struct sja1105_spi_setup *spi_setup, int port,
+                                struct sja1105_xmii_params_entry *params,
+                                struct sja1105_mac_config_entry  *mac_config);
 
 int mii_clocking_setup(struct sja1105_spi_setup *spi_setup, int port,
                        int mii_mode);

--- a/src/lib/include/dynamic-config.h
+++ b/src/lib/include/dynamic-config.h
@@ -68,4 +68,11 @@ int sja1105_mgmt_route_get(struct sja1105_spi_setup*, struct sja1105_mgmt_entry*
 int sja1105_mgmt_route_set(struct sja1105_spi_setup*, struct sja1105_mgmt_entry*, int index);
 void sja1105_mgmt_entry_show(struct sja1105_mgmt_entry *entry);
 
+int sja1105_mac_config_get(struct sja1105_spi_setup *spi_setup,
+                           struct sja1105_mac_config_entry *entry,
+                           int port);
+int sja1105_mac_config_set(struct sja1105_spi_setup *spi_setup,
+                           struct sja1105_mac_config_entry *entry,
+                           int port);
+
 #endif

--- a/src/tool/internal.h
+++ b/src/tool/internal.h
@@ -54,6 +54,8 @@ int ptp_parse_args(struct sja1105_spi_setup*, int argc, char **argv);
 int config_parse_args(struct sja1105_spi_setup*, int argc, char **argv);
 int status_parse_args(struct sja1105_spi_setup*, int argc, char **argv);
 int reg_parse_args(struct sja1105_spi_setup*, int argc, char **argv);
+int reconfig_parse_args(struct sja1105_spi_setup*, int argc, char **argv);
+
 int staging_area_modify(struct sja1105_staging_area*, char*, char*, char*);
 int staging_area_modify_parse(struct sja1105_staging_area*,
                               int *argc, char ***argv);

--- a/src/tool/main.c
+++ b/src/tool/main.c
@@ -48,6 +48,7 @@ void print_usage()
 	       "   * status\n"
 	       "   * reset\n"
 	       "   * reg\n"
+	       "   * reconfig\n"
 	       "   * help | -h | --help\n"
 	       "   * version | -V | --version\n");
 	printf("\n");
@@ -117,12 +118,14 @@ static int parse_args(struct sja1105_spi_setup *spi_setup, int argc, char **argv
 		"status",
 		"reset",
 		"reg",
+		"reconfigure",
 	};
 	int (*next_parse_args[])(struct sja1105_spi_setup*, int, char**) = {
 		config_parse_args,
 		status_parse_args,
 		rgu_parse_args,
 		reg_parse_args,
+		reconfig_parse_args,
 	};
 	int  rc;
 

--- a/src/tool/parse-reconfig.c
+++ b/src/tool/parse-reconfig.c
@@ -88,10 +88,22 @@ int reconfig_parse_args(struct sja1105_spi_setup *spi_setup,
 			goto out_static_config_mismatch;
 		}
 
-		/* Read, modify and write mac config table */
-		rc = sja1105_mac_config_get(spi_setup, &mac_entry, port);
-		if (rc < 0) {
-			goto out_read_failed;
+		/* Read, modify and write MAC config table */
+		if (IS_PQRS(spi_setup->device_id)) {
+			/* We can read from the device via the MAC
+			 * reconfiguration tables. In fact we do just that.
+			 */
+			rc = sja1105_mac_config_get(spi_setup, &mac_entry, port);
+			if (rc < 0) {
+				goto out_read_failed;
+			}
+		} else {
+			/* On E/T, MAC reconfig tables are not readable.
+			 * We have to *know* what the MAC looks like.
+			 * We'll use the static configuration tables as a
+			 * reasonable approximation.
+			 */
+			mac_entry = staging_area.static_config.mac_config[port];
 		}
 		logv("Setting MAC speed for port %" PRIu64
 		     ": before %" PRIu64 ", now %" PRIu64,

--- a/src/tool/parse-reconfig.c
+++ b/src/tool/parse-reconfig.c
@@ -1,0 +1,128 @@
+/*
+ * parse-reconfig.c
+ *
+ *  Created on: Sep 18, 2018
+ *      Author: Georg Waibel
+ */
+#include "internal.h"
+#include <string.h>
+#include <lib/include/status.h>
+#include <lib/include/spi.h>
+#include <lib/include/dynamic-config.h>
+#include <inttypes.h>
+
+static void print_usage()
+{
+	printf("Usage:\n");
+	printf(" * sja1105-tool reconfig speed <port> <speed>: "
+	       "Set a port's (0..4) link speed (10, 100, 1000)\n");
+}
+
+int reconfig_parse_args(struct sja1105_spi_setup *spi_setup,
+                      int argc, char **argv)
+{
+	uint64_t port;
+	uint64_t speed_mbps;
+	uint64_t speed;
+	struct sja1105_staging_area staging_area;
+	struct sja1105_mac_config_entry mac_entry;
+	int rc = 0;
+
+	if (argc < 3) {
+		rc = -EINVAL;
+		goto out_parse_error;
+	}
+
+	if (matches(argv[0], "speed") == 0) {
+		rc = reliable_uint64_from_string(&port, argv[1], NULL);
+		if (rc < 0) {
+			loge("could not read port param %s", argv[1]);
+			goto out_parse_error;
+		}
+		if (port >= 5) {
+			rc = -EINVAL;
+			loge("invalid port %s", argv[1]);
+			goto out_parse_error;
+		}
+		rc = reliable_uint64_from_string(&speed_mbps, argv[2], NULL);
+		if (rc < 0) {
+			loge("could not read speed param %s", argv[2]);
+			goto out_parse_error;
+		}
+		switch (speed_mbps)
+		{
+		case 10:
+			speed = 3;
+			break;
+		case 100:
+			speed = 2;
+			break;
+		case 1000:
+			speed = 1;
+			break;
+		default:
+			rc = -EINVAL;
+			loge("invalid speed %s", argv[2]);
+			goto out_parse_error;
+			break;
+		}
+
+		rc = sja1105_spi_configure(spi_setup);
+		if (rc < 0) {
+			loge("sja1105_spi_configure failed");
+			goto out_spi_configure_failed;
+		}
+
+		rc = staging_area_load(spi_setup->staging_area, &staging_area);
+		if (rc < 0) {
+			loge("loading staging area failed");
+			goto out_read_config_failed;
+		}
+
+		/* Check if speed in staic config is 0 */
+		if (staging_area.static_config.mac_config[port].speed != 0) {
+			rc = -EINVAL;
+			loge("error, static speed config shall be 0, but is %u",
+			     (unsigned)staging_area.static_config.mac_config[port].speed);
+			goto out_static_config_missmatch;
+		}
+
+		/* Read, modify and write mac config table */
+		rc = sja1105_mac_config_get(spi_setup, &mac_entry, port);
+		if (rc < 0) {
+			goto out_read_failed;
+		}
+		logv("Setting MAC speed for port %u: Speed value before: %u, now: %u",
+		     (unsigned)port, (unsigned)mac_entry.speed,
+		     (unsigned)speed);
+		mac_entry.speed = speed;
+		rc = sja1105_mac_config_set(spi_setup, &mac_entry, port);
+		if (rc < 0) {
+			goto out_read_failed;
+		}
+
+		/* Configure the CGU (PHY link modes and speeds) */
+		rc = sja1105_clocking_setup_port(spi_setup, port,
+		                     &staging_area.static_config.xmii_params[0],
+		                     &mac_entry);
+		if (rc < 0) {
+			loge("sja1105_clocking_setup failed");
+			goto out_write_failed;
+		}
+	} else {
+		rc = -EINVAL;
+		loge("command line not understood");
+		goto out_parse_error;
+	}
+
+	return 0;
+
+out_parse_error:
+	print_usage();
+out_static_config_missmatch:
+out_spi_configure_failed:
+out_read_config_failed:
+out_write_failed:
+out_read_failed:
+	return rc;
+}

--- a/src/tool/parse-reconfig.c
+++ b/src/tool/parse-reconfig.c
@@ -49,8 +49,7 @@ int reconfig_parse_args(struct sja1105_spi_setup *spi_setup,
 			loge("could not read speed param %s", argv[2]);
 			goto out_parse_error;
 		}
-		switch (speed_mbps)
-		{
+		switch (speed_mbps) {
 		case 10:
 			speed = 3;
 			break;
@@ -64,7 +63,6 @@ int reconfig_parse_args(struct sja1105_spi_setup *spi_setup,
 			rc = -EINVAL;
 			loge("invalid speed %s", argv[2]);
 			goto out_parse_error;
-			break;
 		}
 
 		rc = sja1105_spi_configure(spi_setup);
@@ -79,12 +77,15 @@ int reconfig_parse_args(struct sja1105_spi_setup *spi_setup,
 			goto out_read_config_failed;
 		}
 
-		/* Check if speed in staic config is 0 */
+		/* Check if speed in static config is 0 */
 		if (staging_area.static_config.mac_config[port].speed != 0) {
 			rc = -EINVAL;
-			loge("error, static speed config shall be 0, but is %u",
-			     (unsigned)staging_area.static_config.mac_config[port].speed);
-			goto out_static_config_missmatch;
+			loge("Speed for port %" PRIu64 " is currently fixed at %" PRIu64 ".",
+			     port, staging_area.static_config.mac_config[port].speed);
+			loge("To allow reconfiguration, run:\n"
+			     "$ sja1105-tool config modify -f mac-configuration-table[%"
+			     PRIu64 "] speed 0", port);
+			goto out_static_config_mismatch;
 		}
 
 		/* Read, modify and write mac config table */
@@ -92,9 +93,9 @@ int reconfig_parse_args(struct sja1105_spi_setup *spi_setup,
 		if (rc < 0) {
 			goto out_read_failed;
 		}
-		logv("Setting MAC speed for port %u: Speed value before: %u, now: %u",
-		     (unsigned)port, (unsigned)mac_entry.speed,
-		     (unsigned)speed);
+		logv("Setting MAC speed for port %" PRIu64
+		     ": before %" PRIu64 ", now %" PRIu64,
+		     port, mac_entry.speed, speed);
 		mac_entry.speed = speed;
 		rc = sja1105_mac_config_set(spi_setup, &mac_entry, port);
 		if (rc < 0) {
@@ -119,7 +120,7 @@ int reconfig_parse_args(struct sja1105_spi_setup *spi_setup,
 
 out_parse_error:
 	print_usage();
-out_static_config_missmatch:
+out_static_config_mismatch:
 out_spi_configure_failed:
 out_read_config_failed:
 out_write_failed:


### PR DESCRIPTION
Hi,
I added a new command to set the port speed at runtime if the speed parameter was set to 0 in the static configuration (MAC config table):
sja1105-tool reconfig speed 2 100 => set port2 speed to 100Mb.
I wonder if this is of interest generally...
The command currently only works for the PQRS devices. If desired I could implement it for the ET devices as well, but I have no hardware to test this on.

Regards 
Georg
