### PR TITLE
Memory corruption fixes (found by Microsys while porting to LS1046)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 tags
 src/helpers/sja1105.bin
 src/helpers/_build
+*.o
+*.so
+.cproject
+.project
+sja1105-tool

--- a/src/common.h
+++ b/src/common.h
@@ -31,12 +31,15 @@
 #ifndef _SJA1105_TOOL_COMMON_H
 #define _SJA1105_TOOL_COMMON_H
 
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <errno.h>
 
 /* These are our own error codes */
 #include <lib/include/errors.h>
+
+#define FREE(P) {if (P) {free(P); (P)=NULL;}} /* robust free() */
 
 /* Since remapping is used internally, and many checks
  * search for a negative return code, we do that here.

--- a/src/common.h
+++ b/src/common.h
@@ -39,8 +39,6 @@
 /* These are our own error codes */
 #include <lib/include/errors.h>
 
-#define FREE(P) {if (P) {free(P); (P)=NULL;}} /* robust free() */
-
 /* Since remapping is used internally, and many checks
  * search for a negative return code, we do that here.
  * The sign is flipped again when returning the error

--- a/src/lib/include/spi.h
+++ b/src/lib/include/spi.h
@@ -37,14 +37,14 @@
 struct sja1105_spi_setup {
 	uint64_t    device_id;
 	uint64_t    part_nr; /* Needed for P/R distinction (same switch core) */
-	const char *device;
+	char *device;
 	uint8_t     mode;
 	uint8_t     bits;
 	uint32_t    speed;
 	uint16_t    delay;
 	int         cs_change;
 	int         dry_run;
-	const char *staging_area;
+	char *staging_area;
 	int         flush;
 	int         fd;
 };

--- a/src/tool/config-show.c
+++ b/src/tool/config-show.c
@@ -62,13 +62,14 @@
 			     entry_count - 1);                                \
 			return -1;                                            \
 		}                                                             \
+		for (i=0;i<MAX_TABLE_SIZE;i++) print_bufs[i] = NULL; \
 		printf(STRING_NAME ": %d entries\n", entry_count);            \
 		for (i = start; i < end; i++) {                               \
 			print_bufs[i] = calloc(sizeof(char), MAX_LINE_SIZE);  \
 			if (print_bufs[i] == NULL) {                          \
 				loge("malloc failed");                        \
 				while (i-- > start) {                         \
-					free(print_bufs[i]);                  \
+					  FREE(print_bufs[i]);                  \
 				}                                             \
 				return -1;                                    \
 			}                                                     \
@@ -83,7 +84,7 @@
 		}                                                             \
 		show_print_bufs(print_bufs + start, end - start);             \
 		for (i = start; i < end; i++) {                               \
-			free(print_bufs[i]);                                  \
+			FREE(print_bufs[i]);                  \
 		}                                                             \
 		return 0;                                                     \
 	}

--- a/src/tool/config-show.c
+++ b/src/tool/config-show.c
@@ -69,7 +69,7 @@
 			if (print_bufs[i] == NULL) {                          \
 				loge("malloc failed");                        \
 				while (i-- > start) {                         \
-					  FREE(print_bufs[i]);                  \
+					  if (print_bufs[i]) free(print_bufs[i]);      \
 				}                                             \
 				return -1;                                    \
 			}                                                     \
@@ -84,7 +84,7 @@
 		}                                                             \
 		show_print_bufs(print_bufs + start, end - start);             \
 		for (i = start; i < end; i++) {                               \
-			FREE(print_bufs[i]);                  \
+			if (print_bufs[i]) free(print_bufs[i]);                  \
 		}                                                             \
 		return 0;                                                     \
 	}

--- a/src/tool/main.c
+++ b/src/tool/main.c
@@ -147,11 +147,11 @@ void cleanup(struct sja1105_spi_setup *spi_setup)
 	extern const char *default_staging_area;
 
 	if (spi_setup->device && spi_setup->device != default_device) {
-		free((char*) spi_setup->device);
+		FREE(spi_setup->device);
 	}
 	if (spi_setup->staging_area &&
 	    spi_setup->staging_area != default_staging_area) {
-		free((char*) spi_setup->staging_area);
+		FREE(spi_setup->staging_area);
 	}
 	if (spi_setup->fd) {
 		close(spi_setup->fd);

--- a/src/tool/main.c
+++ b/src/tool/main.c
@@ -147,11 +147,11 @@ void cleanup(struct sja1105_spi_setup *spi_setup)
 	extern const char *default_staging_area;
 
 	if (spi_setup->device && spi_setup->device != default_device) {
-		FREE(spi_setup->device);
+		if (spi_setup->device) free(spi_setup->device);
 	}
 	if (spi_setup->staging_area &&
 	    spi_setup->staging_area != default_staging_area) {
-		FREE(spi_setup->staging_area);
+		if (spi_setup->staging_area) free(spi_setup->staging_area);
 	}
 	if (spi_setup->fd) {
 		close(spi_setup->fd);

--- a/src/tool/parse-status.c
+++ b/src/tool/parse-status.c
@@ -51,44 +51,40 @@ static int status_ports(struct sja1105_spi_setup *spi_setup,
 	/* XXX Maybe not quite right? */
 	int   size = 10 * MAX_LINE_SIZE;
 	int   rc;
-	int   i;
+	int   i, j;
 
 	if (port_no == -1) {
 		/* Show for all ports */
 		for (i = 0; i < 5; i++) {
-			print_buf[i] = (char*) calloc(size, sizeof(char));
-		}
-		for (i = 0; i < 5; i++) {
 			rc = sja1105_port_status_get(spi_setup, &status, i);
 			if (rc < 0) {
 				loge("sja1105_port_status_get failed");
+				/* free all buffers that have been allocated so far
+				   before leaving the loop and the function: */
+				for (j = 0; j < i; j++) free(print_buf[j]);
 				goto out;
 			}
+			print_buf[i] = (char*) calloc(size, sizeof(char));
 			sja1105_port_status_show(&status, i, print_buf[i],
 			                         spi_setup->device_id);
 		}
 		linewise_concat(print_buf, 5);
 
-		for (i = 0; i < 5; i++) {
-			FREE(print_buf[i]);
-		}
+		for (i = 0; i < 5; i++) free(print_buf[i]);
 	} else {
 		/* Show for single port */
-		print_buf[0] = (char*) calloc(size, sizeof(char));
 		rc = sja1105_port_status_get(spi_setup, &status, port_no);
 		if (rc < 0) {
 			loge("sja1105_port_status_get failed");
 			goto out;
 		}
+		print_buf[0] = (char*) calloc(size, sizeof(char));
 		sja1105_port_status_show(&status, port_no, print_buf[0],
 		                         spi_setup->device_id);
 		printf("%s\n", print_buf[0]);
-		FREE(print_buf[0]);
+		free(print_buf[0]);
 	}
 out:
-	for (i = 0; i < 5; i++) {
-		FREE(print_buf[i]);
-	}
 	return rc;
 }
 

--- a/src/tool/parse-status.c
+++ b/src/tool/parse-status.c
@@ -70,7 +70,7 @@ static int status_ports(struct sja1105_spi_setup *spi_setup,
 		linewise_concat(print_buf, 5);
 
 		for (i = 0; i < 5; i++) {
-			free(print_buf[i]);
+			FREE(print_buf[i]);
 		}
 	} else {
 		/* Show for single port */
@@ -83,9 +83,12 @@ static int status_ports(struct sja1105_spi_setup *spi_setup,
 		sja1105_port_status_show(&status, port_no, print_buf[0],
 		                         spi_setup->device_id);
 		printf("%s\n", print_buf[0]);
-		free(print_buf[0]);
+		FREE(print_buf[0]);
 	}
 out:
+	for (i = 0; i < 5; i++) {
+		FREE(print_buf[i]);
+	}
 	return rc;
 }
 

--- a/src/tool/staging-area.c
+++ b/src/tool/staging-area.c
@@ -121,7 +121,7 @@ staging_area_hexdump(const char *staging_area_file)
 	}
 	logi("static config: dumped %d bytes", rc);
 filesystem_error3:
-	free(buf);
+	FREE(buf);
 filesystem_error2:
 	close(fd);
 filesystem_error1:
@@ -176,7 +176,7 @@ staging_area_load(const char *staging_area_file,
 	}
 	return 0;
 filesystem_error3:
-	free(buf);
+	FREE(buf);
 filesystem_error2:
 	close(fd);
 filesystem_error1:
@@ -224,13 +224,14 @@ staging_area_save(const char *staging_area_file,
 
 	rc = reliable_write(fd, buf, staging_area_len);
 	if (rc < 0) {
+		close(fd); /* close fd before leaving */
 		goto out_2;
 	}
 	logv("done");
 
 	close(fd);
 out_2:
-	free(buf);
+	FREE(buf);
 out_1:
 	return rc;
 }
@@ -276,7 +277,7 @@ static_config_upload(struct sja1105_spi_setup *spi_setup,
 	                                      config_buf,
 	                                      config_buf_len);
 out_free:
-	free(config_buf);
+	FREE(config_buf);
 out:
 	return rc;
 }

--- a/src/tool/staging-area.c
+++ b/src/tool/staging-area.c
@@ -117,11 +117,15 @@ staging_area_hexdump(const char *staging_area_file)
 	rc = sja1105_static_config_hexdump(buf);
 	if (rc < 0) {
 		loge("error while interpreting config");
+		/* free 'buf' and close the file handle 'fd'
+		   before leaving the function: */
+		if (buf != NULL) free(buf);
+		close(fd);
 		goto invalid_staging_area_error;
 	}
 	logi("static config: dumped %d bytes", rc);
 filesystem_error3:
-	FREE(buf);
+	if (buf != NULL) free(buf);
 filesystem_error2:
 	close(fd);
 filesystem_error1:
@@ -172,11 +176,15 @@ staging_area_load(const char *staging_area_file,
 	rc = sja1105_static_config_unpack(buf, static_config);
 	if (rc < 0) {
 		loge("error while interpreting config");
+		/* free 'buf' and close the file handle 'fd'
+		   before leaving the function: */
+		if (buf != NULL) free(buf);
+		close(fd);
 		goto invalid_staging_area_error;
 	}
 	return 0;
 filesystem_error3:
-	FREE(buf);
+	if (buf != NULL) free(buf);
 filesystem_error2:
 	close(fd);
 filesystem_error1:
@@ -231,7 +239,7 @@ staging_area_save(const char *staging_area_file,
 
 	close(fd);
 out_2:
-	FREE(buf);
+	if (buf != NULL) free(buf);
 out_1:
 	return rc;
 }
@@ -277,7 +285,7 @@ static_config_upload(struct sja1105_spi_setup *spi_setup,
 	                                      config_buf,
 	                                      config_buf_len);
 out_free:
-	FREE(config_buf);
+	if (config_buf != NULL) free(config_buf);
 out:
 	return rc;
 }

--- a/src/tool/strings.c
+++ b/src/tool/strings.c
@@ -82,11 +82,11 @@ int get_match(const char *cmd, const char **options, int option_count)
 			printf("   * %s\n", cmd_matches[i]);
 		}
 	};
-	for (i = 0; i < match_count; i++) {
-		free(cmd_matches[i]);
-	}
 out:
-	free(cmd_matches);
+	for (i = 0; i < option_count; i++) {
+		FREE(cmd_matches[i]);
+	}
+	FREE(cmd_matches);
 out_1:
 	return (match_count == 1) ? match_index : -1;
 }
@@ -253,8 +253,8 @@ void linewise_concat(char **buffers, int count)
 			printf("\n");
 		}
 	}
-	free(next_line);
-	free(current_line);
+	FREE(next_line);
+	FREE(current_line);
 }
 
 /*

--- a/src/tool/strings.c
+++ b/src/tool/strings.c
@@ -84,9 +84,9 @@ int get_match(const char *cmd, const char **options, int option_count)
 	};
 out:
 	for (i = 0; i < option_count; i++) {
-		FREE(cmd_matches[i]);
+		if (cmd_matches[i]) free(cmd_matches[i]);
 	}
-	FREE(cmd_matches);
+	if (cmd_matches) free(cmd_matches);
 out_1:
 	return (match_count == 1) ? match_index : -1;
 }
@@ -226,7 +226,16 @@ void linewise_concat(char **buffers, int count)
 	int i;
 
 	next_line    = (char**) calloc(count, sizeof(char*));
+	if (!next_line) {
+		loge("calloc() failed!");
+		return;
+	}
 	current_line = (char**) calloc(count, sizeof(char*));
+	if (!current_line) {
+		free(next_line);
+		loge("calloc() failed!");
+		return;
+	}
 
 	for (i = 0; i < count; i++) {
 		current_line[i] = buffers[i];
@@ -253,8 +262,8 @@ void linewise_concat(char **buffers, int count)
 			printf("\n");
 		}
 	}
-	FREE(next_line);
-	FREE(current_line);
+	free(next_line);
+	free(current_line);
 }
 
 /*

--- a/src/tool/tool-config-file.c
+++ b/src/tool/tool-config-file.c
@@ -81,8 +81,8 @@ config_set_defaults(struct sja1105_spi_setup *spi_setup,
 		struct_ptr->field = value; \
 	}
 	SET_DEFAULT_VAL(spi_setup, device_id, default_device_id, logv, "0x%" PRIx64);
-	SET_DEFAULT_VAL(spi_setup, device, default_device, logi, "%s");
-	SET_DEFAULT_VAL(spi_setup, staging_area, default_staging_area, logi, "%s");
+	SET_DEFAULT_VAL(spi_setup, device, strdup(default_device), logi, "%s");
+	SET_DEFAULT_VAL(spi_setup, staging_area, strdup(default_staging_area), logi, "%s");
 	SET_DEFAULT_VAL(spi_setup, mode, SPI_CPHA, logi, "0x%x" );
 	SET_DEFAULT_VAL(spi_setup, bits, 8, logi, "%d");
 	SET_DEFAULT_VAL(spi_setup, speed, 1000000, logi, "%u");
@@ -305,7 +305,7 @@ int read_config_file(char *filename, struct sja1105_spi_setup *spi_setup,
 		if (p[0] == '[') {
 			/* This is a section header */
 			if (section_hdr != NULL) {
-				free(section_hdr);
+				FREE(section_hdr);
 			}
 			section_hdr = strdup(p);
 			continue;
@@ -336,7 +336,7 @@ int read_config_file(char *filename, struct sja1105_spi_setup *spi_setup,
 	}
 out:
 	if (section_hdr != NULL) {
-		free(section_hdr);
+		FREE(section_hdr);
 	}
 	fclose(fd);
 default_conf:

--- a/src/tool/tool-config-file.c
+++ b/src/tool/tool-config-file.c
@@ -305,7 +305,7 @@ int read_config_file(char *filename, struct sja1105_spi_setup *spi_setup,
 		if (p[0] == '[') {
 			/* This is a section header */
 			if (section_hdr != NULL) {
-				FREE(section_hdr);
+				free(section_hdr);
 			}
 			section_hdr = strdup(p);
 			continue;
@@ -336,7 +336,7 @@ int read_config_file(char *filename, struct sja1105_spi_setup *spi_setup,
 	}
 out:
 	if (section_hdr != NULL) {
-		FREE(section_hdr);
+		free(section_hdr);
 	}
 	fclose(fd);
 default_conf:


### PR DESCRIPTION
Compiled and ported sja1105-tool on LS1046. The fixes are necessary, because the tool terminated
with segmentation fault or occasionally with 'unmap: invalid pointer'.