### PR TITLE
Calculate correct L2 Address Lookup Table (FDB) indices automatically

### DIFF
--- a/docs/md/sja1105-tool-config-format.5.md
+++ b/docs/md/sja1105-tool-config-format.5.md
@@ -226,7 +226,10 @@ following children:
 * "macaddr", bits 83-36
 * "destports", bits 35-31
 * "enfport", bits 30-30
-* "index", bits 29-20
+* Field "index" does not refer to bits 29-20 of the table entry.
+  Instead, the latter is calculated automatically and placed in the
+  staging area. The "index" field from the XML is merely a visual
+  indicator to a human readers.
 
 L2 POLICING TABLE
 -----------------
@@ -456,6 +459,13 @@ The following facts are noted:
 
 * The "index" attribute of each entry is not required nor is it
   interpreted by _sja1105-tool_; it is simply for ease of reading.
+  This is true even for the "l2-address-lookup-table", whose entries do
+  have a field which is actually called "index". In that case, the tool
+  performs automatic calculation of the correct index where the switch
+  hardware searches in the FDB, and places that number into the "index"
+  field of "l2-address-lookup-table" entries. That value and the "index"
+  value specified in the XML are completely separate, with the former
+  being non-user-modifiable, and the latter being ignored by the tool.
 * The first 5 entries in the L2 Forwarding Table are per-port.
     * *bc_domain* indicates the Broadcast Domain. The only limitation
       imposed by default is that broadcast frames received on an

--- a/src/lib/include/gtable.h
+++ b/src/lib/include/gtable.h
@@ -41,5 +41,6 @@ int  gtable_pack(void*, uint64_t*, int, int, int);
 void gtable_hexdump(void*, int);
 void gtable_bitdump(void*, int);
 uint32_t ether_crc32_le(void*, unsigned int);
+uint8_t fdb_hash(uint64_t vlanid, uint64_t macaddr, uint64_t poly_koopman);
 
 #endif

--- a/src/lib/include/static-config.h
+++ b/src/lib/include/static-config.h
@@ -111,6 +111,8 @@
 #define MAX_FRAME_MEMORY                         929
 #define MAX_FRAME_MEMORY_RETAGGING               910
 
+#define SJA1105ET_FDB_BIN_SIZE                   4
+
 #define SJA1105E_DEVICE_ID         0x9C00000Cull
 #define SJA1105T_DEVICE_ID         0x9E00030Eull
 #define SJA1105PR_DEVICE_ID        0xAF00030Eull
@@ -429,6 +431,7 @@ struct sja1105_retagging_entry {
 
 struct sja1105_static_config {
 	uint64_t device_id;
+	uint8_t entries_in_fdb_bin[MAX_L2_LOOKUP_COUNT / SJA1105ET_FDB_BIN_SIZE];
 	STATIC_CONFIG_MEMBER(l2_forwarding_params, MAX_L2_FORWARDING_PARAMS_COUNT);
 	STATIC_CONFIG_MEMBER(l2_forwarding, MAX_L2_FORWARDING_COUNT);
 	STATIC_CONFIG_MEMBER(l2_lookup, MAX_L2_LOOKUP_COUNT);

--- a/src/lib/static-config/static-config.c
+++ b/src/lib/static-config/static-config.c
@@ -472,6 +472,7 @@ sja1105_static_config_pack(void *buf, struct sja1105_static_config *config)
 {
 #define PACK_TABLE_IN_BUF_FN(entry_count, entry_size, blk_id, set_fn, array) \
 	if (entry_count) {                                                   \
+		logv("Packing table " #blk_id " to buffer");                 \
 		header.block_id = (blk_id);                                  \
 		header.len = (entry_count) * (entry_size) / 4;               \
 		sja1105_table_header_pack_with_crc(p, &header);              \

--- a/src/tool/config-modify.c
+++ b/src/tool/config-modify.c
@@ -182,7 +182,6 @@ static int l2_lookup_table_entry_modify(
 		"macaddr",
 		"destports",
 		"enfport",
-		"index",
 	};
 	uint64_t *fields[] = {
 		&config->l2_lookup[entry_index].tsreg,
@@ -198,9 +197,8 @@ static int l2_lookup_table_entry_modify(
 		&config->l2_lookup[entry_index].macaddr,
 		&config->l2_lookup[entry_index].destports,
 		&config->l2_lookup[entry_index].enfport,
-		&config->l2_lookup[entry_index].index,
 	};
-	int entry_field_counts[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,};
+	int entry_field_counts[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, };
 	uint64_t tmp;
 	int rc;
 

--- a/src/tool/config-show.c
+++ b/src/tool/config-show.c
@@ -53,7 +53,7 @@
 		                                                              \
 		if (entry_count == 0) {                                       \
 			loge(STRING_NAME " is empty");                        \
-			return -1;                                            \
+			return 0;                                             \
 		}                                                             \
 		if (index < -1 || index >= entry_count) {                     \
 			loge("Index out of bounds!");                         \

--- a/src/tool/config-show.c
+++ b/src/tool/config-show.c
@@ -190,6 +190,8 @@ sja1105_staging_area_show(struct sja1105_staging_area *staging_area,
 		       static_config->device_id, SJA1105_PART_NR_DONT_CARE));
 		for (i = 0; i < ARRAY_SIZE(next_config_table_show); i++) {
 			rc = next_config_table_show[i](static_config, -1);
+			if (rc < 0)
+				goto out;
 		}
 	} else {
 		index_ptr = strchr(table_name, '[');

--- a/src/tool/xml/read/l2-lookup.c
+++ b/src/tool/xml/read/l2-lookup.c
@@ -46,7 +46,6 @@ static int entry_get(xmlNode *node, struct sja1105_l2_lookup_entry *entry)
 	rc |= xml_read_field(&entry->macaddr, "macaddr", node);
 	rc |= xml_read_field(&entry->destports, "destports", node);
 	rc |= xml_read_field(&entry->enfport, "enfport", node);
-	rc |= xml_read_field(&entry->index, "index", node);
 	if (rc < 0) {
 		loge("L2 Lookup entry is incomplete!");
 		return -EINVAL;

--- a/src/tool/xml/write/l2-lookup.c
+++ b/src/tool/xml/write/l2-lookup.c
@@ -53,7 +53,6 @@ l2_address_lookup_table_write(xmlTextWriterPtr writer,
 		rc |= xml_write_field(writer, "macaddr",   config->l2_lookup[i].macaddr);
 		rc |= xml_write_field(writer, "destports", config->l2_lookup[i].destports);
 		rc |= xml_write_field(writer, "enfport",   config->l2_lookup[i].enfport);
-		rc |= xml_write_field(writer, "index",     config->l2_lookup[i].index);
 		rc |= xmlTextWriterEndElement(writer);
 		if (rc < 0) {
 			loge("error while writing l2_lookup Table element %d", i);


### PR DESCRIPTION
Solves https://github.com/openil/sja1105-tool/issues/31

Test on LS1021A-TSN board:
```
sja1105-tool config default ls
sja1105-tool config modify l2-address-lookup-parameters-table dyn_tbsz 0
sja1105-tool config modify l2-address-lookup-table entry-count 1
sja1105-tool config modify l2-address-lookup-table[0] vlanid 0
sja1105-tool config modify l2-address-lookup-table[0] macaddr aa:bb:cc:dd:ee:ff
sja1105-tool config modify l2-address-lookup-table[0] destports $((1<<1))
sja1105-tool config upload

arp -s 172.15.0.99 aa:bb:cc:dd:ee:ff
ping -I eth2 -f 172.15.0.99
sja1105-tool status port | grep N_TXFRM
```