### PR TITLE
Fix compile error

### DIFF
--- a/src/tool/tool-config-file.c
+++ b/src/tool/tool-config-file.c
@@ -83,7 +83,7 @@ config_set_defaults(struct sja1105_spi_setup *spi_setup,
 	SET_DEFAULT_VAL(spi_setup, device_id, default_device_id, logv, "0x%" PRIx64);
 	SET_DEFAULT_VAL(spi_setup, device, default_device, logi, "%s");
 	SET_DEFAULT_VAL(spi_setup, staging_area, default_staging_area, logi, "%s");
-	SET_DEFAULT_VAL(spi_setup, mode, SPI_CPHA, logi, "0x%x" );
+	SET_DEFAULT_VAL(spi_setup, mode, SPI_CPHA, logi, "0x%lx" );
 	SET_DEFAULT_VAL(spi_setup, bits, 8, logi, "%d");
 	SET_DEFAULT_VAL(spi_setup, speed, 1000000, logi, "%u");
 	SET_DEFAULT_VAL(spi_setup, delay, 0, logi, "%u");


### PR DESCRIPTION
Fix -Werror=format compilation error, format %x expects argument of type unsigned int, but argument 7 has type long unsigned int

Fixes #63 